### PR TITLE
refractor: replace ramda dependency with local differenceWith() 

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback } from "react";
 import { Path } from "react-native-svg";
-import differenceWith from "ramda/src/differenceWith";
+import { differenceWith } from "./utils/differenceWith";
 
 import { bodyFront } from "./assets/bodyFront";
 import { bodyBack } from "./assets/bodyBack";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "ramda": "^0.30.1",
     "react-native-svg": "^15.9.0"
   },
   "peerDependencies": {
@@ -28,7 +27,6 @@
     "react-native": "*"
   },
   "devDependencies": {
-    "@types/ramda": "^0.30.2",
     "@types/react": "^18.3.12",
     "@types/react-native": "^0.73.0",
     "jest": "^29.7.0",

--- a/utils/differenceWith.ts
+++ b/utils/differenceWith.ts
@@ -1,0 +1,11 @@
+export function differenceWith<T>(
+  pred: (a: T, b: T) => boolean,
+  list1: ReadonlyArray<T>,
+  list2: ReadonlyArray<T>
+): T[] {
+  if (!Array.isArray(list1) || list1.length === 0) return [];
+  if (!Array.isArray(list2) || list2.length === 0) return [...list1];
+
+  // Return items from list1 that do not match any item in list2 by the predicate
+  return list1.filter((a) => !list2.some((b) => pred(a, b)));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,20 +714,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
-  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
-  dependencies:
-    "@babel/code-frame" "^7.25.9"
-    "@babel/generator" "^7.25.9"
-    "@babel/parser" "^7.25.9"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.25.9"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
   integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
@@ -1257,13 +1244,6 @@
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
   integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
-
-"@types/ramda@^0.30.2":
-  version "0.30.2"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.30.2.tgz#70661b20c1bb969589a551b7134ae75008ffbfb6"
-  integrity sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==
-  dependencies:
-    types-ramda "^0.30.1"
 
 "@types/react-native@^0.73.0":
   version "0.73.0"
@@ -3554,11 +3534,6 @@ queue@6.0.2:
   dependencies:
     inherits "~2.0.3"
 
-ramda@^0.30.1:
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.30.1.tgz#7108ac95673062b060025052cd5143ae8fc605bf"
-  integrity sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==
-
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -4107,11 +4082,6 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-ts-toolbelt@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
-  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
-
 tslib@^2.0.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -4131,13 +4101,6 @@ type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
-
-types-ramda@^0.30.1:
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/types-ramda/-/types-ramda-0.30.1.tgz#03d255128e3696aeaac76281ca19949e01dddc78"
-  integrity sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==
-  dependencies:
-    ts-toolbelt "^9.6.0"
 
 typescript@^5.6.3:
   version "5.6.3"


### PR DESCRIPTION

# Remove Ramda and add native `differenceWith()` utility function.

# Summary
Replaces the `ramda` dependency by introducing a small, typed, zero-dependency `differenceWith` 
This reduces bundle size and maintenance surface while keeping functional parity.
This PR closes #81 

## Motivation
- Reduce external dependencies.
- Avoid pulling all of `ramda` for a single helper.
- Keep behavior identical for `differenceWith` based logic.

## Changes
- **Added** [utils/differenceWith.ts](cci:7://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-0:0):
  - Exports [differenceWith<T>(pred, list1, list2)](cci:1://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-10:1), returns items in `list1` not matching any in `list2` by `pred`.
- **Updated** [index.tsx](cci:7://file:///home/peterc/react-native-body-highlighter/index.tsx:0:0-0:0):
  - Replaced `import differenceWith from "ramda/src/differenceWith";`
  - With `import { differenceWith } from "./utils/differenceWith";`
- **Updated** [package.json](cci:7://file:///home/peterc/react-native-body-highlighter/package.json:0:0-0:0):
  - Removed `"ramda"` from `dependencies`.
  - Removed `"@types/ramda"` from `devDependencies`.

## Implementation Details
- [utils/differenceWith.ts](cci:7://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-0:0):
  - Pure function, preserves inputs.
  - Typed generically for reuse across the codebase.
  - Parity with Ramda’s semantics: filters `list1` items that do not match any `list2` item according to the provided predicate.
- [index.tsx](cci:7://file:///home/peterc/react-native-body-highlighter/index.tsx:0:0-0:0):
  - Continues to use existing [comparison](cci:1://file:///home/peterc/react-native-body-highlighter/index.tsx:62:0-63:20) predicate for `slug` equality.
  - Behavior of merged body parts is unchanged.

### Affected Files
- [utils/differenceWith.ts](cci:7://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-0:0) (new)
- [index.tsx](cci:7://file:///home/peterc/react-native-body-highlighter/index.tsx:0:0-0:0) (import change)
- [package.json](cci:7://file:///home/peterc/react-native-body-highlighter/package.json:0:0-0:0) (remove Ramda deps)

### Backward Compatibility
- No API changes.
- Internal-only refactor with the same output and rendering logic.

### Performance/Size Impact
- Removes Ramda from dependencies, reducing install size and potential bundle footprint.
- The local utility is O(n·m) in worst case, same complexity as typical [differenceWith](cci:1://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-10:1) usage here. Input sizes are small (body part lists), so performance impact is negligible-to-positive.

## Testing
- Built and installed dependencies with Yarn successfully.
- Type-check currently shows React Native vs DOM typing conflicts unrelated to this change. If desired, we can resolve via [tsconfig.json](cci:7://file:///home/peterc/react-native-body-highlighter/tsconfig.json:0:0-0:0):
  - Add `"skipLibCheck": true` and `"lib": ["es6"]` (optionally `"types": ["react", "react-native"]`).
- Functional behavior validated by reading through `mergedBodyParts` logic in [index.tsx](cci:7://file:///home/peterc/react-native-body-highlighter/index.tsx:0:0-0:0):
  - [differenceWith(comparison, dataSource, data)](cci:1://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-10:1) still yields the base parts not present in the provided `data`.

## Notes
- If you prefer, I can add a tiny unit test for [differenceWith](cci:1://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-10:1) covering:
  - Empty arrays
  - No matches
  - Some matches
  - Multiple matches for a single comparator

# Checklist
- [x] Remove `ramda` and `@types/ramda`
- [x] Add native [differenceWith](cci:1://file:///home/peterc/react-native-body-highlighter/utils/differenceWith.ts:0:0-10:1) utility
- [x] Update imports in [index.tsx](cci:7://file:///home/peterc/react-native-body-highlighter/index.tsx:0:0-0:0)
- [x] Yarn install to prune lockfile
- [ ] Resolve RN vs DOM type conflicts (optional, config-level)
- [ ] Tag as a minor refactor release (no breaking changes)

# Screenshots
N/A

# Migration Guide
No changes required for users.