### PR TITLE
Color property should be present on BodyPartObject

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -46,6 +46,7 @@ export interface BodyPart {
 }
 
 export interface ExtendedBodyPart extends BodyPart {
+  color?: string;
   intensity?: number;
   side?: "left" | "right";
 }
@@ -83,9 +84,14 @@ const Body = ({
 
       const coloredBodyParts = innerData.map((d) => {
         const bodyPart = data.find((e) => e.slug === d?.slug);
-        let colorIntensity = 1;
-        if (bodyPart?.intensity) colorIntensity = bodyPart.intensity;
-        return { ...d, color: colors[colorIntensity - 1] };
+
+        if (bodyPart?.color) {
+          return { ...d, color: bodyPart.color };
+        } else {
+          let colorIntensity = 1;
+          if (bodyPart?.intensity) colorIntensity = bodyPart.intensity;
+          return { ...d, color: colors[colorIntensity - 1] };
+        }
       });
 
       const formattedBodyParts = differenceWith(comparison, dataSource, data);
@@ -98,10 +104,10 @@ const Body = ({
   const getColorToFill = (bodyPart: ExtendedBodyPart) => {
     let color;
 
-    if (bodyPart.intensity) {
-      color = colors[bodyPart.intensity];
-    } else {
+    if (bodyPart.color) {
       color = bodyPart.color;
+    } else if (bodyPart.intensity && bodyPart.intensity > 0) {
+      color = colors[bodyPart.intensity];
     }
 
     return color;


### PR DESCRIPTION
# BodyPartObject should have a color property to alter the color of of body parts. 
## Summary
Add `color` property to allow the changing colour of body parts. 
This PR closes #74 
## Changes
* Adding of `color` property to Body.
* Ensure that the logic is altered before intensity property
* Add conditional to change color if it's set.
## Implementation details
* Will work with no `color` set just like usual, should not produce any breaking changes.
## Affected Files
* index.tsx
## Testing
* Built and installed successfully
* Add color property to body parts
```{ slug: "chest", color: '#f100d9ff', intensity: 1, side: "left" }```
* See the color of that part has changed.
* Repeat with multiple parts and multiple colors.
## Screenshots
<img width="429" height="649" alt="image" src="https://github.com/user-attachments/assets/0cfb9d1d-3191-4ba3-b831-8f9cf9cc43aa" />

## Notes
This is my first ever PR. Apologies if I've missed anything or misunderstood.